### PR TITLE
fix(security): veřejné karty trenérů přes service role

### DIFF
--- a/src/app/api/coach-cards/public/route.ts
+++ b/src/app/api/coach-cards/public/route.ts
@@ -1,6 +1,6 @@
 import {NextRequest, NextResponse} from 'next/server';
 
-import {supabaseServerClient} from '@/utils/supabase/server';
+import supabaseAdmin from '@/utils/supabase/admin';
 
 import {getPublishedCoachCardsByCategory} from '@/queries/coachCards';
 
@@ -13,8 +13,11 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const supabase = await supabaseServerClient();
-    const result = await getPublishedCoachCardsByCategory({supabase}, categoryId);
+    // Reads through the service role because `coach_cards_with_categories` is no
+    // longer readable by anon: querying the view directly used to expose cards
+    // their owners never published. The publication filter now lives here,
+    // server-side, where a caller cannot drop it.
+    const result = await getPublishedCoachCardsByCategory({supabase: supabaseAdmin}, categoryId);
 
     if (result.error) {
       return NextResponse.json({error: result.error}, {status: 500});


### PR DESCRIPTION
Doprovod k migraci `20260807_restrict_remaining_public_views.sql`.

## Problém

`coach_cards_with_categories` je čitelný rolí `anon`, takže kdokoli si pohled dotázal přímo a **obešel filtr `published_categories`**, který aplikuje routa `/api/coach-cards/public`. Ověřeno anon klíčem: vrací všech 5 karet trenérů včetně e-mailu a telefonu, přičemž **jedna z nich publikovaná není**.

Kontakty trenérů jako takové veřejné být mají — stránka `/coaches` je zobrazuje záměrně. Chybí jen to omezení na publikované karty.

## Řešení

Migrace odebere pohledu přístup pro `anon`. Tahle routa ho ale četla právě jako `anon` (`supabaseServerClient()` bez session), takže by přestala fungovat — proto přechází na service-role klienta. Filtr publikovaných karet tím zůstává na serveru, kde ho volající nemůže zahodit.

## Souvislosti

Vzniklo při procházení Supabase security linteru. První migrace (`20260807_lock_down_member_data_and_rls.sql`, už spuštěná) zavřela vážnější únik — anon si mohl stáhnout 201 členů včetně rodných dat, kontaktů na zákonné zástupce a zdravotních poznámek.

Commit původně omylem skončil na už zamergované větvi `deps-security-updates`, odsud je cherry-pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)