### PR TITLE
fix(security): obnovit karty trenérů na veřejných stránkách kategorií

### DIFF
--- a/src/utils/categoryPageData.ts
+++ b/src/utils/categoryPageData.ts
@@ -3,6 +3,7 @@
  * Please use the new data fetching utilities in src/lib/data instead.
  * @todo REFACTOR: This file is getting quite large and complex. Consider breaking it down into smaller modules. Consider if it is still needed.
  */
+import supabaseAdmin from '@/utils/supabase/admin';
 import {supabaseServerClient} from '@/utils/supabase/server';
 
 import {isPlayoffPhase} from '@/enums';
@@ -423,7 +424,14 @@ export async function getCategoryPageData(
     springMatches.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
     playoffMatches.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
-    const coachCardsResult = await getPublishedCoachCardsByCategory({supabase}, category.id);
+    // Service role, not the request client: `coach_cards_with_categories` is no
+    // longer readable by anon, so an anonymous visitor's client returns nothing
+    // here. The published-categories filter inside the query is what keeps
+    // unpublished cards out.
+    const coachCardsResult = await getPublishedCoachCardsByCategory(
+      {supabase: supabaseAdmin},
+      category.id
+    );
 
     return {
       category: category as any,


### PR DESCRIPTION
**Oprava produkčního výpadku.** Po odebrání anon přístupu k `coach_cards_with_categories` zmizely kontakty na trenéry z veřejných stránek kategorií.

## Co jsem přehlédl

PR #76 opravil `/api/coach-cards/public`. Jenže ta routa obsluhuje `CoachContactsSection` — komponentu, kterou **nikde nic nerenderuje**. Skutečný veřejný konzument je server component `/categories/[slug]`, který jde na stejný dotaz přes `getCategoryPageData`, a to **klientem requestu** — tedy pro nepřihlášeného návštěvníka rolí `anon`. Ta na pohled po migraci nemá právo, takže se vrátilo prázdno.

Ověřeno proti produkci: `/api/coach-cards/public` vrací data správně (HTTP 200), rozbitá byla jen tahle druhá cesta.

## Oprava

`getCategoryPageData` volá dotaz service-role klientem, stejně jako už opravená routa. Filtr `published_categories` uvnitř dotazu dál rozhoduje, co se zobrazí, takže nepublikované karty ven neuniknou.

Prověřil jsem, že jiná cesta ke `coach_cards` v kódu není: zbývá už jen `coachAuth.ts`, což je serverová autorizace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)